### PR TITLE
Implement `$out`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Aggify is a Python library for generating MongoDB aggregation pipelines, designe
 - [x] `$lookup`: Performs a left outer join to combine documents from two collections.
 - [x] `$sort`: Sorts the documents in the aggregation pipeline.
 - [x] `$conf`:
-- [ ] `$addFields`: Adds new fields to the documents in the pipeline.
-- [ ] `$replaceRoot`: Replaces the document structure with a new one.
+- [x] `$out`: Writes the result of the aggregation pipeline to a new collection.
 - [x] `$group` (with accumulators): Performs various aggregation operations like counting, summing, averaging, and more.
+- [x] `$addFields`: Adds new fields to the documents in the pipeline.
+- [ ] `$replaceRoot`: Replaces the document structure with a new one.
 - [ ] `$project` (with expressions): Allows you to use expressions to reshape and calculate values.
 - [ ] `$redact`: Controls document inclusion during the aggregation pipeline.
-- [ ] `$out`: Writes the result of the aggregation pipeline to a new collection.
 
 - [x] Q function : object is primarily used for complex queries that require logical operations
 - [x] F function : object represents the value of a model field, its transformed value, or an annotated column

--- a/aggify/aggify.py
+++ b/aggify/aggify.py
@@ -128,7 +128,7 @@ class Aggify:
 
               For a sharded cluster, the specified output database must already exist.
 
-        db is None:
+        if db is None:
           { $out: "<output-collection>" } // Output collection is in the same database
 
         Notes:
@@ -144,9 +144,14 @@ class Aggify:
             you must first delete and then re-create the search index.
             Consider using $merge instead.
 
-        from docs: https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/
+        from: https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/
         """
-        pass
+        if db is None:
+            stage = {'$out': coll}
+        else:
+            stage = {'$out': {'db': db, 'coll': coll}}
+        self.pipelines.append(stage)
+        return self
 
     def __to_aggregate(self, query: dict[str, Any]) -> None:
         """

--- a/aggify/aggify.py
+++ b/aggify/aggify.py
@@ -24,7 +24,7 @@ def last_out_stage_check(method):
     @functools.wraps(method)
     def decorator(*args, **kwargs):
         try:
-            if is_last_out := bool(args[0].pipelines[-1].get("out")):
+            if last_is_out := bool(args[0].pipelines[-1].get("$out")):
                 raise OutStageError(method.__name__)
         except IndexError:
             return method(*args, **kwargs)
@@ -147,9 +147,9 @@ class Aggify:
         from: https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/
         """
         if db is None:
-            stage = {'$out': coll}
+            stage = {"$out": coll}
         else:
-            stage = {'$out': {'db': db, 'coll': coll}}
+            stage = {"$out": {"db": db, "coll": coll}}
         self.pipelines.append(stage)
         return self
 

--- a/aggify/exceptions.py
+++ b/aggify/exceptions.py
@@ -16,6 +16,7 @@ class InvalidPipelineStageError(AggifyBaseException):
 
     Subclass and customise for the raised exception in the methods
     """
+
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
@@ -27,7 +28,7 @@ class AnnotationError(InvalidPipelineStageError):
 
 class OutStageError(InvalidPipelineStageError):
     def __init__(self, stage):
-        self.message = f'You cannot add a {self!r} pipeline after $out stage!'
+        self.message = f"You cannot add a {self!r} pipeline after $out stage!"
         super().__init__(self.message)
 
 

--- a/aggify/exceptions.py
+++ b/aggify/exceptions.py
@@ -8,23 +8,36 @@ class AggifyBaseException(Exception):
 class MongoIndexError(AggifyBaseException):
     def __init__(self):
         self.message = "Index error is invalid, please use int or slice without step!"
-
         super().__init__(self.message)
 
 
-class AnnotationError(AggifyBaseException):
+class InvalidPipelineStageError(AggifyBaseException):
+    """General parent exception for all `pipeline stage` methods
+
+    Subclass and customise for the raised exception in the methods
+    """
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
 
 
+class AnnotationError(InvalidPipelineStageError):
+    pass
+
+
+class OutStageError(InvalidPipelineStageError):
+    def __init__(self, stage):
+        self.message = f'You cannot add a {self!r} pipeline after $out stage!'
+        super().__init__(self.message)
+
+
 class AggifyValueError(AggifyBaseException):
-    def __init__(self, expecteds: list[Type], result: Type):
+    def __init__(self, expected_list: list[Type], result: Type):
         self.message = (
-            f"Input is not correctly passed, expected either of {[expected for expected in expecteds]}"
+            f"Input is not correctly passed, expected either of {[expected for expected in expected_list]}"
             f"but got {result}"
         )
-        self.expecteds = expecteds
+        self.expecteds = expected_list
         self.result = result
 
         super().__init__(self.message)
@@ -40,3 +53,7 @@ class InvalidField(AggifyBaseException):
     def __init__(self, field: str):
         self.message = f"Field {field} does not exists."
         super().__init__(self.message)
+
+
+class _:
+    pass

--- a/aggify/utilty.py
+++ b/aggify/utilty.py
@@ -41,7 +41,9 @@ def check_fields_exist(model: Document, fields_to_check: list[str]) -> None:
     Raises:
         InvalidField: If any of the specified fields are missing in the model's fields.
     """
-    missing_fields = [field for field in fields_to_check if not model._fields.get(field)]  # noqa
+    missing_fields = [
+        field for field in fields_to_check if not model._fields.get(field)
+    ]  # noqa
     if missing_fields:
         raise InvalidField(field=missing_fields[0])
 
@@ -67,8 +69,8 @@ def replace_values_recursive(obj, replacements):
         for key, value in obj.items():
             updated_stage[key] = replace_values_recursive(value, replacements)
         return updated_stage
-    elif str(obj).replace("$", '') in replacements:
-        return replacements[obj.replace("$", '')]
+    elif str(obj).replace("$", "") in replacements:
+        return replacements[obj.replace("$", "")]
     else:
         return obj
 
@@ -96,7 +98,7 @@ def convert_match_query(d: dict) -> dict:
     if isinstance(d, dict):
         new_dict = {}
         for key, value in d.items():
-            if isinstance(value, dict) and ('$eq' in value or '$ne' in value):
+            if isinstance(value, dict) and ("$eq" in value or "$ne" in value):
                 for operator, operand in value.items():
                     new_dict[operator] = [f"${key}", operand]
             else:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,23 +6,22 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'Aggify'
-copyright = '2023, SeYeD.Dev'
-author = 'SeYeD.Dev'
-release = '0.1.2'
+project = "Aggify"
+copyright = "2023, SeYeD.Dev"
+author = "SeYeD.Dev"
+release = "0.1.2"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = []
 
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
-
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
-html_static_path = ['_static']
+html_theme = "alabaster"
+html_static_path = ["_static"]

--- a/tests/test_aggify.py
+++ b/tests/test_aggify.py
@@ -268,3 +268,16 @@ class TestAggify:
         aggify.out("coll")
         with pytest.raises(OutStageError):
             getattr(Aggify, method)(aggify, *args)
+
+    def test_out_db_none(self):
+        aggify = Aggify(BaseModel)
+        aggify.out("collection")
+        assert len(aggify.pipelines) == 1
+        assert aggify.pipelines[-1]["$out"] == "collection"
+
+    def test_out(self):
+        aggify = Aggify(BaseModel)
+        aggify.out("collection", "db_name")
+        assert len(aggify.pipelines) == 1
+        assert aggify.pipelines[-1]["$out"]["db"] == "db_name"
+        assert aggify.pipelines[-1]["$out"]["coll"] == "collection"

--- a/tests/test_aggify.py
+++ b/tests/test_aggify.py
@@ -26,7 +26,6 @@ class TestAggify:
         aggify = Aggify(BaseModel)
         thing = aggify[0:10]
         assert isinstance(thing, Aggify)
-        print(thing.pipelines)
         assert thing.pipelines[-1]["$limit"] == 10
         assert thing.pipelines[-2]["$skip"] == 0
 
@@ -40,7 +39,6 @@ class TestAggify:
         aggify = Aggify(BaseModel)
         aggify.filter(age__gte=30).project(name=1, age=1)
         assert len(aggify.pipelines) == 2
-        print(type(aggify.pipelines[1]))
         assert aggify.pipelines[1]["$project"] == {"name": 1, "age": 1}
 
     def test_filtering_and_ordering(self):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -232,7 +232,7 @@ cases = [
             {"$match": {"posts": {"$ne": []}}},
         ],
     ),
-    TestCase(
+    ParameterTestCase(
         compiled_query=(
             Aggify(PostDocument).replace_root(embedded_field='stat')
         ),
@@ -240,7 +240,7 @@ cases = [
             {'$replaceRoot': {'$newRoot': '$stat'}}
         ],
     ),
-    TestCase(
+    ParameterTestCase(
         compiled_query=(
             Aggify(PostDocument).replace_with(embedded_field='stat')
         ),
@@ -248,7 +248,7 @@ cases = [
             {'$replaceWith': '$stat'}
         ],
     ),
-    TestCase(
+    ParameterTestCase(
         compiled_query=(
             Aggify(PostDocument).replace_with(embedded_field='stat', merge={
                 "like_count": 0,
@@ -263,7 +263,7 @@ cases = [
                                                 '$stat']}}
         ],
     ),
-    TestCase(
+    ParameterTestCase(
         compiled_query=(
             Aggify(PostDocument).replace_root(embedded_field='stat', merge={
                 "like_count": 0,

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -131,57 +131,96 @@ cases = [
     ParameterTestCase(
         compiled_query=(
             Aggify(PostDocument).lookup(
-                AccountDocument, query=[  # noqa
-                    Q(_id__ne='owner') & Q(username__ne='seyed'),
-                ], let=['owner'], as_name='posts'
+                AccountDocument,
+                query=[  # noqa
+                    Q(_id__ne="owner") & Q(username__ne="seyed"),
+                ],
+                let=["owner"],
+                as_name="posts",
             )
         ),
         expected_query=[
-            {'$lookup': {'as': 'posts',
-                         'from': 'account',
-                         'let': {'owner': '$owner_id'},
-                         'pipeline': [{'$match': {'$expr': {'$and': [{'$ne': ['$_id',
-                                                                              '$$owner']},
-                                                                     {'$ne': ['$username',
-                                                                              'seyed']}]}}}]}}
+            {
+                "$lookup": {
+                    "as": "posts",
+                    "from": "account",
+                    "let": {"owner": "$owner_id"},
+                    "pipeline": [
+                        {
+                            "$match": {
+                                "$expr": {
+                                    "$and": [
+                                        {"$ne": ["$_id", "$$owner"]},
+                                        {"$ne": ["$username", "seyed"]},
+                                    ]
+                                }
+                            }
+                        }
+                    ],
+                }
+            }
         ],
     ),
     ParameterTestCase(
         compiled_query=(
-            Aggify(PostDocument).lookup(
-                AccountDocument, query=[  # noqa
-                    Q(_id__ne='owner') & Q(username__ne='seyed'),
-                ], let=['owner'], as_name='posts'
-            ).filter(posts__ne=[])
+            Aggify(PostDocument)
+            .lookup(
+                AccountDocument,
+                query=[  # noqa
+                    Q(_id__ne="owner") & Q(username__ne="seyed"),
+                ],
+                let=["owner"],
+                as_name="posts",
+            )
+            .filter(posts__ne=[])
         ),
         expected_query=[
-            {'$lookup': {'as': 'posts',
-                         'from': 'account',
-                         'let': {'owner': '$owner_id'},
-                         'pipeline': [{'$match': {'$expr': {'$and': [{'$ne': ['$_id',
-                                                                              '$$owner']},
-                                                                     {'$ne': ['$username',
-                                                                              'seyed']}]}}}]}},
-            {'$match': {'posts': {'$ne': []}}}
+            {
+                "$lookup": {
+                    "as": "posts",
+                    "from": "account",
+                    "let": {"owner": "$owner_id"},
+                    "pipeline": [
+                        {
+                            "$match": {
+                                "$expr": {
+                                    "$and": [
+                                        {"$ne": ["$_id", "$$owner"]},
+                                        {"$ne": ["$username", "seyed"]},
+                                    ]
+                                }
+                            }
+                        }
+                    ],
+                }
+            },
+            {"$match": {"posts": {"$ne": []}}},
         ],
     ),
     ParameterTestCase(
         compiled_query=(
-            Aggify(PostDocument).lookup(
-                AccountDocument, query=[  # noqa
-                    Q(_id__exact='owner'),
-                    Q(username__exact='caption')
-                ], let=['owner', 'caption'], as_name='posts'
-            ).filter(posts__ne=[])
+            Aggify(PostDocument)
+            .lookup(
+                AccountDocument,
+                query=[Q(_id__exact="owner"), Q(username__exact="caption")],  # noqa
+                let=["owner", "caption"],
+                as_name="posts",
+            )
+            .filter(posts__ne=[])
         ),
         expected_query=[
-            {'$lookup': {'as': 'posts',
-                         'from': 'account',
-                         'let': {'caption': '$caption', 'owner': '$owner_id'},
-                         'pipeline': [{'$match': {'$expr': {'$eq': ['$_id', '$$owner']}}},
-                                      {'$match': {'$expr': {'$eq': ['$username',
-                                                                    '$$caption']}}}]}},
-            {'$match': {'posts': {'$ne': []}}}
+            {
+                "$lookup": {
+                    "as": "posts",
+                    "from": "account",
+                    "let": {"caption": "$caption", "owner": "$owner_id"},
+                    "pipeline": [
+                        {"$match": {"$expr": {"$eq": ["$_id", "$$owner"]}}},
+                        {"$match": {"$expr": {"$eq": ["$username", "$$caption"]}}},
+                    ],
+                }
+            },
+            {"$match": {"posts": {"$ne": []}}},
         ],
     ),
 ]

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -41,13 +41,13 @@ class PostDocument(Document):
 
 
 @dataclass
-class TestCase:
+class ParameterTestCase:
     compiled_query: Aggify
     expected_query: list
 
 
 cases = [
-    TestCase(
+    ParameterTestCase(
         compiled_query=Aggify(PostDocument).filter(
             caption__contains="hello", owner__deleted_at=None
         ),
@@ -65,7 +65,7 @@ cases = [
             {"$match": {"owner.deleted_at": None}},
         ],
     ),
-    TestCase(
+    ParameterTestCase(
         compiled_query=Aggify(PostDocument)
         .filter(caption__contains="hello")
         .project(caption=1, deleted_at=0),
@@ -74,7 +74,7 @@ cases = [
             {"$project": {"caption": 1, "deleted_at": 0}},
         ],
     ),
-    TestCase(
+    ParameterTestCase(
         compiled_query=Aggify(PostDocument).filter(
             (Q(caption__contains=["hello"]) | Q(location__contains="test"))
             & Q(deleted_at=None)
@@ -100,15 +100,15 @@ cases = [
             }
         ],
     ),
-    TestCase(
+    ParameterTestCase(
         compiled_query=Aggify(PostDocument).filter(caption="hello")[3:10],
         expected_query=[{"$match": {"caption": "hello"}}, {"$skip": 3}, {"$limit": 7}],
     ),
-    TestCase(
+    ParameterTestCase(
         compiled_query=Aggify(PostDocument).filter(caption="hello").order_by("-_id"),
         expected_query=[{"$match": {"caption": "hello"}}, {"$sort": {"_id": -1}}],
     ),
-    TestCase(
+    ParameterTestCase(
         compiled_query=(
             Aggify(PostDocument).add_fields(
                 {
@@ -128,7 +128,7 @@ cases = [
             }
         ],
     ),
-    TestCase(
+    ParameterTestCase(
         compiled_query=(
             Aggify(PostDocument).lookup(
                 AccountDocument, query=[  # noqa
@@ -146,7 +146,7 @@ cases = [
                                                                               'seyed']}]}}}]}}
         ],
     ),
-    TestCase(
+    ParameterTestCase(
         compiled_query=(
             Aggify(PostDocument).lookup(
                 AccountDocument, query=[  # noqa
@@ -165,7 +165,7 @@ cases = [
             {'$match': {'posts': {'$ne': []}}}
         ],
     ),
-    TestCase(
+    ParameterTestCase(
         compiled_query=(
             Aggify(PostDocument).lookup(
                 AccountDocument, query=[  # noqa
@@ -188,7 +188,7 @@ cases = [
 
 
 @pytest.mark.parametrize("case", cases)
-def test_query_compiler(case: TestCase):
+def test_query_compiler(case: ParameterTestCase):
     print(str(case.compiled_query))
     print(case.compiled_query.pipelines)
     print(case.expected_query)


### PR DESCRIPTION
# What's Changed

This pull request implements the `$out` stage of MongoDB aggregation pipeline.

### Added
- Add `InvalidPipelineStageError` base exception
- Add `OutStageError` exception
- Add last_out_stage_check` decorator
- Add `out` method

### Changed
- `TestCase` dataclass is now named as `ParameterTestCase` so that pytest doesn't complain about its name
- `AnnotationError` now inherits from `InvalidPipelineStageError`

### Removed
- remove `print`s in the tests
