### PR TITLE
Simplify field key assertions using set comparison

### DIFF
--- a/tests/test_aggify.py
+++ b/tests/test_aggify.py
@@ -52,14 +52,14 @@ class TestAggify:
         aggify.filter(age__gte=30).project(name=1, age=1)
         assert len(aggify.pipelines) == 2
         assert aggify.pipelines[1]["$project"] == {"name": 1, "age": 1}
-        assert list(aggify.base_model._fields.keys()) == ["name", "age", "id"]
+        assert aggify.base_model._fields.keys() == {"name", "age", "id"} 
 
     def test_filtering_and_projection_with_deleting_id(self):
         aggify = Aggify(BaseModel)
         aggify.filter(age__gte=30).project(name=1, age=1, id=0)
         assert len(aggify.pipelines) == 2
         assert aggify.pipelines[1]["$project"] == {"_id": 0, "name": 1, "age": 1}
-        assert list(aggify.base_model._fields.keys()) == ["name", "age"]
+        assert aggify.base_model._fields.keys() == {"name", "age"}
 
     def test_filtering_and_ordering(self):
         aggify = Aggify(BaseModel)
@@ -644,7 +644,7 @@ class TestAggify:
         aggify = Aggify(BaseModel)
         thing = list(aggify.project(test="test", id=0))
         assert thing[0]["$project"] == {"test": "test", "_id": 0}
-        assert list(aggify.base_model._fields.keys()) == ["test"]
+        assert aggify.base_model._fields.keys() == {"test"}
 
     def test_lookup_raw_let(self):
         aggify = Aggify(BaseModel)
@@ -662,7 +662,7 @@ class TestAggify:
             "pipeline": [{"$match": {"$expr": {"$eq": ["$name", "$$test"]}}}],
             "as": "test_name",
         }
-        assert "test_name" in list(aggify.base_model._fields.keys())
+        assert "test_name" in aggify.base_model._fields.keys()
 
     def test_group_multi_expressions(self):
         thing = list(Aggify(BaseModel).group(["name", "age"]))


### PR DESCRIPTION
This PR updates some assertions in test_aggify.py to:

- Compare directly with a set instead of converting keys to a list for faster lookups O(1).
- Make the tests simpler and cleaner.
- Keep the same test logic and behavior.